### PR TITLE
fix(prosemirror): #WB-1956, corrected default font-family of headers

### DIFF
--- a/scss/components/tiptap/_prosemirror.scss
+++ b/scss/components/tiptap/_prosemirror.scss
@@ -7,4 +7,9 @@
     mark {
         padding-inline: 0;
     }
+
+    /* Headers should use inherited font family. */ 
+    :where(h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6) {
+        font-family: inherit;
+    }
 }


### PR DESCRIPTION
Headers (h1, h2...) should not use the font-family of the app theme.